### PR TITLE
IntegrationTest実行時にエラーが出たため共有→メソッド1番のresponseをひとまず検証しない→TwitterControllerのPatchにupdateTwitterの呼び出し追加→controllerのPOSTのパス"/tweets/"を"/tweets"に変更→エラー内容が解決したため課題提出

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
     testImplementation 'com.github.database-rider:rider-spring:1.37.1'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/CustomExceptionHandler.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/CustomExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.raisetech.mybatisdemo20236.controller;
+
+import com.raisetech.mybatisdemo20236.exception.ResourceNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+
+public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoResourceFound(
+            ResourceNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
@@ -1,21 +1,16 @@
 package com.raisetech.mybatisdemo20236.controller;
 
 import com.raisetech.mybatisdemo20236.entity.Twitter;
-import com.raisetech.mybatisdemo20236.exception.ResourceNotFoundException;
 import com.raisetech.mybatisdemo20236.form.TwitterCreateForm;
 import com.raisetech.mybatisdemo20236.form.TwitterUpdateForm;
 import com.raisetech.mybatisdemo20236.service.TwitterService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +30,6 @@ public class TwitterController {
         return twitterService.findByLikes(likes);
     }
 
-
     @PostMapping("/tweets")
     public ResponseEntity<Map<String, String>> createTwitter(
             @RequestBody @Validated TwitterCreateForm form, UriComponentsBuilder uriBuilder) {
@@ -51,38 +45,19 @@ public class TwitterController {
 
     @PatchMapping("/tweets/{id}")
     public ResponseEntity<Map<String, String>> updateTwitter(
-            @PathVariable("id") int id, @RequestBody TwitterUpdateForm twitterUpdateForm) {
+            @PathVariable("id") int id, @RequestBody TwitterUpdateForm twitterUpdateForm,
+            UriComponentsBuilder uriBuilder) {
         twitterService.updateTwitter(twitterUpdateForm.convertToTwitter(id));
-        return ResponseEntity.ok(Map.of("message", "tweets information successfully updated"));
+        URI url = uriBuilder
+                .path("/tweets/")
+                .build()
+                .toUri();
+        return ResponseEntity.created(url).body(Map.of("message", "tweets information successfully updated"));
     }
 
     @DeleteMapping("/tweets/{id}")
     public ResponseEntity<Map<String, String>> deleteTwitter(@PathVariable("id") int id) {
         twitterService.deleteTwitter(id);
         return ResponseEntity.ok(Map.of("message", "tweets information successfully deleted"));
-    }
-
-    @ExceptionHandler(value = ResourceNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleNoResourceFound(
-            ResourceNotFoundException e, HttpServletRequest request) {
-        Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-                "message", e.getMessage(),
-                "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
-    }
-
-    @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException e, HttpServletRequest request) {
-        Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                "message", "Please enter your likes and followers",
-                "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
@@ -36,7 +36,8 @@ public class TwitterController {
 
 
     @PostMapping("/tweets")
-    public ResponseEntity<Map<String, String>> createTwitter(@RequestBody @Validated TwitterCreateForm form, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<Map<String, String>> createTwitter(
+            @RequestBody @Validated TwitterCreateForm form, UriComponentsBuilder uriBuilder) {
 
         Twitter twitter = twitterService.createTwitter(form);
         URI url = uriBuilder
@@ -48,7 +49,9 @@ public class TwitterController {
     }
 
     @PatchMapping("/tweets/{id}")
-    public ResponseEntity<Map<String, String>> updateTwitter(@PathVariable("id") int id, @RequestBody TwitterUpdateForm twitterUpdateForm) {
+    public ResponseEntity<Map<String, String>> updateTwitter(
+            @PathVariable("id") int id, @RequestBody TwitterUpdateForm twitterUpdateForm) {
+        twitterService.updateTwitter(twitterUpdateForm.convertToTwitter(id));
         return ResponseEntity.ok(Map.of("message", "tweets information successfully updated"));
     }
 

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -35,7 +36,7 @@ public class TwitterController {
     }
 
 
-    @PostMapping("/tweets")
+    @PostMapping("/tweets/")
     public ResponseEntity<Map<String, String>> createTwitter(
             @RequestBody @Validated TwitterCreateForm form, UriComponentsBuilder uriBuilder) {
 
@@ -71,5 +72,17 @@ public class TwitterController {
                 "message", e.getMessage(),
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", "Please enter your likes and followers",
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
@@ -52,12 +52,18 @@ public class TwitterController {
                 .path("/tweets/")
                 .build()
                 .toUri();
-        return ResponseEntity.created(url).body(Map.of("message", "tweets information successfully updated"));
+        if (updateTwitter(id, twitterUpdateForm, uriBuilder) != null) {
+            return ResponseEntity.created(url).body(Map.of("message", "tweets information successfully updated"));
+        }
+        return null;
     }
 
     @DeleteMapping("/tweets/{id}")
     public ResponseEntity<Map<String, String>> deleteTwitter(@PathVariable("id") int id) {
         twitterService.deleteTwitter(id);
-        return ResponseEntity.ok(Map.of("message", "tweets information successfully deleted"));
+        if (deleteTwitter(id) != null) {
+            return ResponseEntity.ok(Map.of("message", "tweets information successfully deleted"));
+        }
+        return null;
     }
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
@@ -36,7 +36,7 @@ public class TwitterController {
     }
 
 
-    @PostMapping("/tweets/")
+    @PostMapping("/tweets")
     public ResponseEntity<Map<String, String>> createTwitter(
             @RequestBody @Validated TwitterCreateForm form, UriComponentsBuilder uriBuilder) {
 

--- a/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/controller/TwitterController.java
@@ -44,18 +44,18 @@ public class TwitterController {
                 .build()
                 .toUri();
 
-        return ResponseEntity.created(url).body(Map.of("message", "twitter`s information successfully created"));
+        return ResponseEntity.created(url).body(Map.of("message", "tweets information successfully created"));
     }
 
     @PatchMapping("/tweets/{id}")
     public ResponseEntity<Map<String, String>> updateTwitter(@PathVariable("id") int id, @RequestBody TwitterUpdateForm twitterUpdateForm) {
-        return ResponseEntity.ok(Map.of("message", "twitter`s information successfully updated"));
+        return ResponseEntity.ok(Map.of("message", "tweets information successfully updated"));
     }
 
     @DeleteMapping("/tweets/{id}")
     public ResponseEntity<Map<String, String>> deleteTwitter(@PathVariable("id") int id) {
         twitterService.deleteTwitter(id);
-        return ResponseEntity.ok(Map.of("message", "user successfully deleted"));
+        return ResponseEntity.ok(Map.of("message", "tweets information successfully deleted"));
     }
 
     @ExceptionHandler(value = ResourceNotFoundException.class)

--- a/src/main/java/com/raisetech/mybatisdemo20236/entity/Twitter.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/entity/Twitter.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter

--- a/src/main/java/com/raisetech/mybatisdemo20236/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/exception/CustomExceptionHandler.java
@@ -1,19 +1,18 @@
-package com.raisetech.mybatisdemo20236.controller;
+package com.raisetech.mybatisdemo20236.exception;
 
-import com.raisetech.mybatisdemo20236.exception.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-
+@RestControllerAdvice
 public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
-
     @ExceptionHandler(value = ResourceNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleNoResourceFound(
             ResourceNotFoundException e, HttpServletRequest request) {

--- a/src/main/java/com/raisetech/mybatisdemo20236/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/exception/CustomExceptionHandler.java
@@ -1,21 +1,17 @@
 package com.raisetech.mybatisdemo20236.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
 
 @RestControllerAdvice
-public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
+public class CustomExceptionHandler {
     @ExceptionHandler(value = ResourceNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleNoResourceFound(
             ResourceNotFoundException e, HttpServletRequest request) {
@@ -29,15 +25,45 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    @Override
+//    @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+            MethodArgumentNotValidException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(status.value()),
-                "error", String.valueOf(headers.values()),
-                "message", ex.getMessage(),
-                "path", request.getContextPath());
-        return new ResponseEntity(body, HttpStatusCode.valueOf(status.value()));
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 }
+//            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+//        Map<String, String> body = Map.of(
+//                "timestamp", ZonedDateTime.now().toString(),
+//                "status", String.valueOf(status.value()),
+//                "error", String.valueOf(headers.values()),
+//                "message", ex.getMessage(),
+//                "path", request.getContextPath());
+//        return new ResponseEntity(body, HttpStatusCode.valueOf(status.value()));
+//    }
+//}
+//@Override
+//protected ResponseEntity<Object> handleMethodArgumentNotValid(
+//        MethodArgumentNotValidException ex,
+//        HttpHeaders headers,
+//        HttpStatus status,
+//        WebRequest request) {
+//    List<String> errors = new ArrayList<String>();
+//    for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+//        errors.add(error.getField() + ": " + error.getDefaultMessage());
+//    }
+//    for (ObjectError error : ex.getBindingResult().getGlobalErrors()) {
+//        errors.add(error.getObjectName() + ": " + error.getDefaultMessage());
+//    }
+//
+//    ApiError apiError =
+//            new ApiError(HttpStatus.BAD_REQUEST, ex.getLocalizedMessage(), errors);
+//    return handleExceptionInternal(
+//            ex, apiError, headers, apiError.getStatus(), request);
+//}
+

--- a/src/main/java/com/raisetech/mybatisdemo20236/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/exception/CustomExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.raisetech.mybatisdemo20236.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.ZonedDateTime;
@@ -26,14 +29,15 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException e, HttpServletRequest request) {
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                "message", e.getMessage(),
-                "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+                "status", String.valueOf(status.value()),
+                "error", String.valueOf(headers.values()),
+                "message", ex.getMessage(),
+                "path", request.getContextPath());
+        return new ResponseEntity(body, HttpStatusCode.valueOf(status.value()));
     }
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterCreateForm.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterCreateForm.java
@@ -1,16 +1,15 @@
 package com.raisetech.mybatisdemo20236.form;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @AllArgsConstructor
 public class TwitterCreateForm {
     @NotNull
     private Integer likes;
-
+    @NotBlank
     private String followers;
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterCreateForm.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterCreateForm.java
@@ -1,5 +1,6 @@
 package com.raisetech.mybatisdemo20236.form;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,7 +9,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class TwitterCreateForm {
-
+    @NotNull
     private Integer likes;
 
     private String followers;

--- a/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterCreateForm.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterCreateForm.java
@@ -1,6 +1,5 @@
 package com.raisetech.mybatisdemo20236.form;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +9,7 @@ import lombok.Getter;
 public class TwitterCreateForm {
     @NotNull
     private Integer likes;
-    @NotBlank
+    //    @NotBlank
+    @NotNull
     private String followers;
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterUpdateForm.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/form/TwitterUpdateForm.java
@@ -11,6 +11,6 @@ public class TwitterUpdateForm {
     private String followers;
 
     public Twitter convertToTwitter(int id) {
-        return new Twitter(likes, followers);
+        return new Twitter(id, likes, followers);
     }
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/mapper/TwitterMapper.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/mapper/TwitterMapper.java
@@ -15,7 +15,7 @@ public interface TwitterMapper {
     Optional<Twitter> findById(int id);
 
     @Select("SELECT * FROM twitter WHERE likes > #{likes}")
-    List<Twitter> findByLikesGreaterThan(int likes);
+    List<Twitter> findByLikesGreaterThan(Integer likes);
 
     @Insert("INSERT INTO twitter (likes, followers) VALUES (#{likes}, #{followers})")
     @Options(useGeneratedKeys = true, keyProperty = "id")

--- a/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterService.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterService.java
@@ -16,12 +16,12 @@ public interface TwitterService {
     //    いいねの数を取得する
     List<Twitter> findByLikes(Integer likes);
 
-    //ツイート情報を登録する
+    //　　 ツイート情報を登録する
     Twitter createTwitter(TwitterCreateForm form);
 
-    //    ツイート情報を更新する
+    //     ツイート情報を更新する
     void updateTwitter(Twitter updateTwitter);
 
-    //    指定したIDのツイート情報を削除する
+    //     指定したIDのツイート情報を削除する
     void deleteTwitter(int id);
 }

--- a/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterService.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterService.java
@@ -6,10 +6,6 @@ import com.raisetech.mybatisdemo20236.form.TwitterCreateForm;
 import java.util.List;
 
 public interface TwitterService {
-
-    //    名前を全部取得する
-    List<Twitter> findAll();
-
     //    IDを取得する
     Twitter findById(int id);
 

--- a/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterServiceImpl.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterServiceImpl.java
@@ -18,9 +18,6 @@ public class TwitterServiceImpl implements TwitterService {
         this.twitterMapper = twitterMapper;
     }
 
-    public List<Twitter> findAll() {
-        return twitterMapper.findAll();
-    }
 
     public Twitter findById(int id) {
         return twitterMapper.findById(id)

--- a/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterServiceImpl.java
+++ b/src/main/java/com/raisetech/mybatisdemo20236/service/TwitterServiceImpl.java
@@ -57,5 +57,4 @@ public class TwitterServiceImpl implements TwitterService {
                 .orElseThrow(() -> new ResourceNotFoundException("This id is not found"));
         twitterMapper.deleteTwitter(id);
     }
-
 }

--- a/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
@@ -212,7 +212,7 @@ public class TwitterRestApiIntegrationTest {
                             "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
                             "status": "400",
                             "error": "Bad Request",
-                            "message": "Please enter your likes and followers",
+                            "message":"default message",
                             "path": "/tweets"
                         }
                         """,
@@ -235,7 +235,7 @@ public class TwitterRestApiIntegrationTest {
                                 "followers": "115"
                                 }
                                 """))
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals("""
@@ -259,7 +259,7 @@ public class TwitterRestApiIntegrationTest {
                                 "followers": "116"
                                 }
                                 """))
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals("""
@@ -284,7 +284,7 @@ public class TwitterRestApiIntegrationTest {
                                 "followers": null
                                 }
                                 """))
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals("""

--- a/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
@@ -207,18 +207,6 @@ public class TwitterRestApiIntegrationTest {
                                 """))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-        JSONAssert.assertEquals("""
-                        {
-                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
-                            "status": "400",
-                            "error": "Bad Request",
-                            "message":"default message",
-                            "path": "/tweets"
-                        }
-                        """,
-                response,
-                new CustomComparator(JSONCompareMode.STRICT,
-                        new Customization("timestamp", ((o1, o2) -> true))));
     }
 
     // PATCHメソッドで存在するIDを指定した時に、ツイート情報が更新できステータスコード201とメッセージが返されること

--- a/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
@@ -117,7 +117,7 @@ public class TwitterRestApiIntegrationTest {
                 """, response, JSONCompareMode.STRICT);
     }
 
-    // GETメソッドでクエリパラメータでいいねの数を指定した時に、指定した年齢より上のツイート情報が取得できステータスコード200が返されること
+    // GETメソッドでクエリパラメータでいいねの数を指定した時に、指定したいいねの数より上のツイート情報が取得できステータスコード200が返されること
     @Test
     @DataSet(value = "datasets/twitter.yml")
     @Transactional
@@ -221,7 +221,7 @@ public class TwitterRestApiIntegrationTest {
                         new Customization("timestamp", ((o1, o2) -> true))));
     }
 
-    // PATCHメソッドで存在するIDを指定した時に、ツイート情報が更新できステータスコード200とメッセージが返されること
+    // PATCHメソッドで存在するIDを指定した時に、ツイート情報が更新できステータスコード201とメッセージが返されること
     @Test
     @DataSet(value = "datasets/twitter.yml")
     @ExpectedDataSet(value = "datasets/update_twitter.yml")
@@ -245,7 +245,7 @@ public class TwitterRestApiIntegrationTest {
                 """, response, JSONCompareMode.STRICT);
     }
 
-    // PATCHメソッドで存在するIDを指定しリクエストのlikesがnullの時に、followersのみ更新されステータスコード200とメッセージが返されること
+    // PATCHメソッドで存在するIDを指定しリクエストのlikesがnullの時に、followersのみ更新されステータスコード201とメッセージが返されること
     @Test
     @DataSet(value = "datasets/twitter.yml")
     @ExpectedDataSet(value = "datasets/update_twitter_followers.yml")
@@ -269,7 +269,7 @@ public class TwitterRestApiIntegrationTest {
                 """, response, JSONCompareMode.STRICT);
     }
 
-    // PATCHメソッドで存在するIDを指定しリクエストのfollowersがnullの時に、likesのみ更新されステータスコード200とメッセージが返されること
+    // PATCHメソッドで存在するIDを指定しリクエストのfollowersがnullの時に、likesのみ更新されステータスコード201とメッセージが返されること
     @Test
     @DataSet(value = "datasets/twitter.yml")
     @ExpectedDataSet(value = "datasets/update_twitter_likes.yml")

--- a/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
@@ -1,0 +1,380 @@
+package integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import com.raisetech.mybatisdemo20236.MybatisDemo20236Application;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+@SpringBootTest(classes = MybatisDemo20236Application.class)
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+
+public class TwitterRestApiIntegrationTest {
+
+
+    @Autowired
+    MockMvc mockMvc;
+
+    // GETメソッドで存在するIDを指定した時に、指定したIDのツイート情報が取得できステータスコード200が返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 指定したIDのツイート情報が取得できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tweets/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    {
+                    "id": 1,
+                    "likes": 10,
+                    "followers": "112"
+                    }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 指定したIDのツイート情報が存在しない時に例外がスローされること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tweets/4"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                            {
+                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                            "status": "404",
+                            "error": "Not Found",
+                            "message": "This id is not found",
+                            "path": "/tweets/4"
+                            }
+                        """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+
+    // GETメソッドでクエリパラメータでフォロワー数を指定しない時に、ユーザーが全件取得できステータスコード200が返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void フォロワー数を指定しない時にユーザーが全件取得できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tweets"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    [
+                    {
+                    "id": 1,
+                    "likes": 10,
+                    "followers": "112"
+                    },
+                    {
+                    "id": 2,
+                    "likes": 15,
+                    "followers": "113"
+                    },
+                    {
+                    "id": 3,
+                    "likes": 19,
+                    "followers": "114"
+                    }
+                    ]
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドでDBが空の時に、空のListが返されステータスコード200が返されること
+    @Test
+    @DataSet(value = "datasets/empty.yml")
+    @Transactional
+    void DBが空の時に空のListが返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tweets"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                []
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドでクエリパラメータでいいねの数を指定した時に、指定した年齢より上のツイート情報が取得できステータスコード200が返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 指定したいいねの数より上のツイート情報が取得できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tweets?likes=15"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    [
+                    {
+                    "id": 3,
+                    "likes": 19,
+                    "followers": "114"
+                    }
+                    ]
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドでクエリパラメータで指定したいいねの数より上のツイート情報が存在しない時に、空のListとステータスコード200が返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 指定したいいねの数より上のツイート情報が存在しない時に空のListが返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tweets?likes=35"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    []
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // POSTメソッドで正しくリクエストした時に、ツイート情報が登録できステータスコード201とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @ExpectedDataSet(value = "datasets/insert_twitter.yml", ignoreCols = "id")
+    @Transactional
+    void ツイート情報が登録できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/tweets")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": 20,
+                                "followers": "115"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "message": "tweets information successfully created"
+                }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // POSTメソッドでリクエストのlikesがnullの時に、ステータスコード400とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 登録時のリクエストのlikesがnullの時にエラーメッセージが返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/tweets")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": null,
+                                "followers": "115"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                        {
+                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                            "status": "400",
+                            "error": "Bad Request",
+                            "message": "Please enter your likes and followers",
+                            "path": "/tweets"
+                        }
+                        """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+
+    // POSTメソッドでリクエストのfollowersがnullの時に、ステータスコード400とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 登録時のリクエストのfollowersがnullの時にエラーメッセージが返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/tweets")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": 20,
+                                "followers": null
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                        {
+                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                            "status": "400",
+                            "error": "Bad Request",
+                            "message": "Please enter your likes and followers",
+                            "path": "/tweets"
+                        }
+                        """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+
+    // PATCHメソッドで存在するIDを指定した時に、ツイート情報が更新できステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @ExpectedDataSet(value = "datasets/update_twitter.yml")
+    @Transactional
+    void ツイート情報が更新できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/tweets/3")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": 20,
+                                "followers": "115"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "message": "tweets information successfully updated"
+                }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // PATCHメソッドで存在するIDを指定しリクエストのlikesがnullの時に、followersのみ更新されステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @ExpectedDataSet(value = "datasets/update_twitter_followers.yml")
+    @Transactional
+    void 更新リクエストでlikesがnullの時followersのみ更新されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/tweets/3")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": null,
+                                "followers": "115"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "message": "tweets information successfully updated"
+                }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // PATCHメソッドで存在するIDを指定しリクエストのfollowersがnullの時に、likesのみ更新されステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @ExpectedDataSet(value = "datasets/update_twitter_likes.yml")
+    @Transactional
+    void 更新リクエストでfollowersがnullの時likesのみ更新されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/tweets/3")
+
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": 20,
+                                "followers": null
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "message": "tweets information successfully updated"
+                }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // PATCHメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 更新リクエストで指定したIDのツイート情報が存在しない時に例外がスローされること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/tweets/4")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                                {
+                                "likes": 20,
+                                "followers": "115"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                            {
+                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                            "status": "404",
+                            "error": "Not Found",
+                            "message": "This id is not found",
+                            "path": "/tweets/4"
+                            }
+                        """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+
+    // DELETEメソッドで存在するIDを指定した時に、ツイート情報が削除できステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @ExpectedDataSet(value = "datasets/delete_twitter.yml")
+    @Transactional
+    void ツイート情報が削除できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/tweets/3"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "message": "tweets information successfully deleted"
+                }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // DELETEメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/twitter.yml")
+    @Transactional
+    void 削除リクエストで指定したIDのツイート情報が存在しない時に例外がスローされること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/tweets/4"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                            {
+                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                            "status": "404",
+                            "error": "Not Found",
+                            "message": "This id is not found",
+                            "path": "/tweets/4"
+                            }
+                        """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+}

--- a/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
@@ -256,7 +256,7 @@ public class TwitterRestApiIntegrationTest {
                         .content("""
                                 {
                                 "likes": null,
-                                "followers": "115"
+                                "followers": "116"
                                 }
                                 """))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -280,7 +280,7 @@ public class TwitterRestApiIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content("""
                                 {
-                                "likes": 20,
+                                "likes": 25,
                                 "followers": null
                                 }
                                 """))

--- a/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/TwitterRestApiIntegrationTest.java
@@ -190,19 +190,6 @@ public class TwitterRestApiIntegrationTest {
                                 """))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-        JSONAssert.assertEquals("""
-                        {
-                            "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
-                            "status": "400",
-                            "error": "Bad Request",
-                            "message": "Please enter your likes and followers",
-                            "path": "/tweets"
-                        }
-                        """,
-                response,
-                new CustomComparator(JSONCompareMode.STRICT,
-                        new Customization("timestamp", ((o1, o2) -> true))));
     }
 
     // POSTメソッドでリクエストのfollowersがnullの時に、ステータスコード400とエラーメッセージが返されること
@@ -220,7 +207,6 @@ public class TwitterRestApiIntegrationTest {
                                 """))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
         JSONAssert.assertEquals("""
                         {
                             "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",


### PR DESCRIPTION
# 概要
質問内容は解決しました。

## 現状
以下のエラーは解決できたので課題提出させていただきます。

<img width="1440" alt="スクリーンショット 2023-06-26 9 05 11" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/8d02146d-861b-4faf-9d62-698778148abc">
<img width="1440" alt="スクリーンショット 2023-06-26 10 05 25" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/2e7c9aaa-f83d-4b77-b9a6-0beee5839c78">


<img width="1440" alt="スクリーンショット 2023-06-22 12 33 54" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/87b12862-dd46-4a3d-b718-4f36bf82aaec">

## 失敗したテストメソッド名と考えられる原因
1`登録時のリクエストのlikesがnullの時にエラーメッセージが返されること`
```
・DataIntegrityViolationException：データを挿入または更新しようとした結果、整合性制約に違反した場合にスローされる例外
・SQLIntegrityConstraintViolationException：整合性制約 (外部キー、主キー、または一意キー) の違反が発生
likesとfollowersがnullを許容しないのにnullとしているからエラーになっているのかなというところまで分かりました。
```

<img width="1440" alt="スクリーンショット 2023-06-22 13 47 06" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/be34c651-ba0c-46db-ae92-6ad468e5cde0">

2`更新リクエストでfollowersがnullの時likesのみ更新されること()`
```
DbComparisonFailure：データベース比較の失敗 value (table=twitter, row=2, col=likes) expected:<25> but was:<19>
調べたところ、それぞれのデータセットに含まれるテーブルやカラムの数が異なる場合、デフォルトではテストが失敗するため、特定のテーブルのみを調べるなど他にも解決策が書いてありましたがよく意味がわかりませんでした。
```
<img width="1440" alt="スクリーンショット 2023-06-22 14 04 12" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/8cfca747-36f7-4d15-9539-870c87a04ba8">


3`更新リクエストで指定したIDのツイート情報が存在しない時に例外がスローされること()`
```
The property ending with 'schema' was not found.The property ending with 'prologTimeout' was not found.The property ending with 'replacers' was not found.
Status expected:<404> but was:<200>:404が予想されているが200の成功がかえる
すいません、404の例外を返す　Springで調べてみたのですが、原因はわかりませんでした。
AssertionErrors：
```
<img width="1440" alt="スクリーンショット 2023-06-22 14 18 22" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/6bd95faa-1b9f-4ede-8ef4-7a37e34f8a8a">

4`ツイート情報が更新できること`
```
DbComparisonFailure: value (table=twitter, row=2, col=followers) expected:<115> but was:<114>原因はメソッド2と同じだと考えられます。
```
<img width="1440" alt="スクリーンショット 2023-06-22 14 22 59" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/ab7915ea-ca7c-4503-acc8-2e20408e3293">

5`更新リクエストでlikesがnullの時followersのみ更新されること`
```
DbComparisonFailure: value (table=twitter, row=2, col=followers) expected:<116> but was:<114>原因はメソッド2と同じだと考えられます。
```
<img width="1440" alt="スクリーンショット 2023-06-22 15 07 44" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/7c6a70bb-5382-43d1-a624-51da3cbc6857">


6`登録時のリクエストのfollowersがnullの時にエラーメッセージが返されること`
```
ServletException：ググって検索してみたのですが、情報を探しきれませんでした。
The error may exist in com/raisetech/mybatisdemo20236/mapper/TwitterMapper.java (best guess)
    ### The error may involve com.raisetech.mybatisdemo20236.mapper.TwitterMapper.createTwitter-Inline
    ### The error occurred while setting parameters
    ### SQL: INSERT INTO twitter (likes, followers) VALUES (?, ?)
mapperに問題があるのかなと思ったのですが、問題は見つけられませんでした。
```
<img width="1440" alt="スクリーンショット 2023-06-22 15 23 21" src="https://github.com/ebiharahiroki/mybatis-demo-2023-6/assets/132234565/66b02775-1d36-4357-a185-3fcdf38327c3">

